### PR TITLE
Add setup script for lint dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,16 @@ npm run dev
 - Click on "New codespace" to launch a new Codespace environment.
 - Edit files directly within the Codespace and commit and push your changes once you're done.
 
+## Development setup
+
+Run the setup script after cloning to install all dependencies, including ESLint packages required for linting.
+
+```sh
+npm run setup
+```
+
+After running the script you can execute `npm run lint` on a fresh environment without missing packages.
+
 ## What technologies are used for this project?
 
 This project is built with:

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
+    "setup": "sh ./setup.sh",
     "lint": "eslint .",
     "preview": "vite preview"
   },

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+# Project setup script
+# Installs all dependencies including lint packages so linting works on fresh clones
+npm install


### PR DESCRIPTION
## Summary
- create `setup.sh` to install all dependencies
- expose the setup command in `package.json`
- document the setup step in the README

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*